### PR TITLE
fixed  worker file without `self`

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -31,8 +31,8 @@ process.once("message", function (obj) {
 		postMessage: function postMessage(msg) {
 			process.send(JSON.stringify({ data: msg }));
 		},
-		onmessage: noop,
-		onerror: noop,
+		onmessage: undefined,
+		onerror: undefined,
 		addEventListener: function addEventListener(event, fn) {
 			if (event === "message") {
 				global.onmessage = global.self.onmessage = fn;

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,8 +29,8 @@ process.once("message", function (obj) {
 		postMessage: function (msg) {
 			process.send(JSON.stringify({data: msg}));
 		},
-		onmessage: noop,
-		onerror: noop,
+		onmessage: undefined,
+		onerror: undefined,
 		addEventListener: function (event, fn) {
 			if (event === "message") {
 				global.onmessage = global.self.onmessage = fn;


### PR DESCRIPTION
it will noop when definition  without `self` like this

``` javascript
onmessage = function (ev) {
    postMessage(ev.data);
};
```

So it's compatible with this worker
