### PR TITLE
Use SIGINT instead of SIGHUP to kill child

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class Worker {
 	}
 
 	terminate () {
-		this.child.kill("SIGHUP");
+		this.child.kill("SIGINT");
 	}
 }
 


### PR DESCRIPTION
`kill("SIGHUP")` does not work on Windows:

```
Error: kill ENOSYS
    at exports._errnoException (util.js:870:11)
    at ChildProcess.kill (internal/child_process.js:374:13)
    at Worker.terminate (C:\Users\xkr47\project\node_modules\tiny-worker\lib\index.js:55:15)
```

`SIGINT` works however, and fix confirmed elsewhere also: https://github.com/balderdashy/sails/issues/846#issuecomment-25187082
