### PR TITLE
Set __dirname and __filename relative to worker path

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -43,8 +43,8 @@ process.once("message", function (obj) {
 		}
 	};
 
-	global.__dirname = __dirname;
-	global.__filename = __filename;
+	global.__dirname = path.resolve(path.dirname(obj.input));
+	global.__filename = path.resolve(obj.input);
 	global.require = require;
 
 	global.importScripts = function () {


### PR DESCRIPTION
This patch gives behavior similar to what I see with a regular `process.fork`. While this patch allows `console.log(__dirname)` in the worker to print the desired output, the problem remains that `require` still wants to import from the `node_modules/tiny-worker/lib` directory.

If you apply this patch, then the user can simply import within workers by using `require(path.join(__dirname, "script.js"))` to open neighboring scripts. If not, then the worker script likely won't know its own path, so it should be unable to require scripts in its directory in an installation location independent way.
