### PR TITLE
automatic redirection of debug port of child process

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ var Worker = function () {
 				);
 			});
 
-			if (portIndex > 0) {
+			if (portIndex >= 0) {
 				//set new port, ignore "-brk", it doesn't work
 				debugVars[portIndex] = (/^--debug/.test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
 			}

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ var Worker = function () {
 
 			var portIndex = debugVars.findIndex(function (debugArg) {
 				//get index of debug port specifier
-				return (/^--(debug|inspect)(-brk)?=\d*/.test(debugArg)
+				return (/^--(debug|inspect)(-brk)?\d*/.test(debugArg)
 				);
 			});
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ var Worker = function () {
 
 			var portIndex = debugVars.findIndex(function (debugArg) {
 				//get index of debug port specifier
-				return (/^--(debug|inspect)(-brk)?\d*/.test(debugArg)
+				return (/^--(debug|inspect)(-brk)?(=\d+)?$/.test(debugArg)
 				);
 			});
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,31 @@ var Worker = function () {
 			options.cwd = process.cwd();
 		}
 
+		//get all debug related parameters
+		var debugVars = process.execArgv.filter(function (execArg) {
+			return (/(debug|inspect)/.test(execArg)
+			);
+		});
+		if (debugVars.lenght > 0) {
+			if (!options.execArgv) {
+				//if no execArgs are given copy all arguments
+				debugVars = process.execArgv;
+				options.execArgv = [];
+			}
+
+			var portIndex = debugVars.findIndex(function (debugArg) {
+				//get index of debug port specifier
+				return (/^--(debug|inspect)(-brk)?=\d*/.test(debugArg)
+				);
+			});
+
+			if (portIndex > 0) {
+				//set new port, ignore "-brk", it doesn't work
+				debugVars[portIndex] = (/^--debug/.test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + process.debugPort + 1;
+			}
+			options.execArgv = options.execArgv.concat(debugVars);
+		}
+
 		this.child = fork(worker, args, options);
 		this.onerror = undefined;
 		this.onmessage = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var path = require("path"),
     fork = require("child_process").fork,
     worker = path.join(__dirname, "worker.js"),
-    events = /^(error|message)$/;
+    events = /^(error|message)$/,
+    defaultPorts = { inspect: 9229, debug: 5858 };
 
 var Worker = function () {
 	function Worker(arg) {
@@ -37,15 +38,33 @@ var Worker = function () {
 				options.execArgv = [];
 			}
 
-			var portIndex = debugVars.findIndex(function (debugArg) {
-				//get index of debug port specifier
-				return (/^--(debug|inspect)(-brk)?(=\d+)?$/.test(debugArg)
+			var inspectIndex = debugVars.findIndex(function (debugArg) {
+				//get index of inspect parameter
+				return (/^--inspect(-brk)?(=\d+)?$/.test(debugArg)
 				);
 			});
 
+			var debugIndex = debugVars.findIndex(function (debugArg) {
+				//get index of debug parameter
+				return (/^--debug(-brk)?(=\d+)?$/.test(debugArg)
+				);
+			});
+
+			var portIndex = inspectIndex >= 0 ? inspectIndex : debugIndex; //get index of port, inspect has higher priority
+
 			if (portIndex >= 0) {
-				//set new port, ignore "-brk", it doesn't work
-				debugVars[portIndex] = (/^--debug/.test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
+				var match = /^--(debug|inspect)(?:-brk)?(?:=(\d+))?$/.exec(debugVars[portIndex]); //get port
+				var port = defaultPorts[match[1]];
+				if (match[2]) {
+					port = parseInt(match[2]);
+				}
+				debugVars[portIndex] = "--" + match[1] + "=" + (port + 1); //new parameter
+
+				if (debugIndex >= 0 && debugIndex !== portIndex) {
+					//remove "-brk" from debug if there
+					match = /^(--debug)(?:-brk)?(.*)/.exec(debugVars[debugIndex]);
+					debugVars[debugIndex] = match[1] + (match[2] ? match[2] : "");
+				}
 			}
 			options.execArgv = options.execArgv.concat(debugVars);
 		}

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ var Worker = function () {
 			return (/(debug|inspect)/.test(execArg)
 			);
 		});
-		if (debugVars.length > 0) {
+		if (debugVars.length > 0 && !options.noDebugRedirection) {
 			if (!options.execArgv) {
 				//if no execArgs are given copy all arguments
 				debugVars = process.execArgv;
@@ -68,6 +68,8 @@ var Worker = function () {
 			}
 			options.execArgv = options.execArgv.concat(debugVars);
 		}
+
+		delete options.noDebugRedirection;
 
 		this.child = fork(worker, args, options);
 		this.onerror = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var Worker = function () {
 			return (/(debug|inspect)/.test(execArg)
 			);
 		});
-		if (debugVars.lenght > 0) {
+		if (debugVars.length > 0) {
 			if (!options.execArgv) {
 				//if no execArgs are given copy all arguments
 				debugVars = process.execArgv;
@@ -45,7 +45,7 @@ var Worker = function () {
 
 			if (portIndex > 0) {
 				//set new port, ignore "-brk", it doesn't work
-				debugVars[portIndex] = (/^--debug/.test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + process.debugPort + 1;
+				debugVars[portIndex] = (/^--debug/.test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
 			}
 			options.execArgv = options.execArgv.concat(debugVars);
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 const path = require("path"),
 	fork = require("child_process").fork,
 	worker = path.join(__dirname, "worker.js"),
-	events = /^(error|message)$/;
+	events = /^(error|message)$/,
+	defaultPorts = {inspect: 9229, debug: 5858};
 
 class Worker {
 	constructor (arg, args = undefined, options = {cwd: process.cwd()}) {
@@ -22,12 +23,28 @@ class Worker {
 				options.execArgv = [];
 			}
 
-			let portIndex = debugVars.findIndex(debugArg => { //get index of debug port specifier
-				return (/^--(debug|inspect)(-brk)?(=\d+)?$/).test(debugArg);
+			let inspectIndex = debugVars.findIndex(debugArg => { //get index of inspect parameter
+				return (/^--inspect(-brk)?(=\d+)?$/).test(debugArg);
 			});
 
-			if (portIndex >= 0) { //set new port, ignore "-brk", it doesn't work
-				debugVars[portIndex] = ((/^--debug/).test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
+			let debugIndex = debugVars.findIndex(debugArg => { //get index of debug parameter
+				return (/^--debug(-brk)?(=\d+)?$/).test(debugArg);
+			});
+
+			let portIndex = inspectIndex >= 0 ? inspectIndex : debugIndex; //get index of port, inspect has higher priority
+
+			if (portIndex >= 0) {
+				var match = (/^--(debug|inspect)(?:-brk)?(?:=(\d+))?$/).exec(debugVars[portIndex]); //get port
+				var port = defaultPorts[match[1]];
+				if (match[2]) {
+					port = parseInt(match[2]);
+				}
+				debugVars[portIndex] = "--" + match[1] + "=" + (port + 1); //new parameter
+
+				if (debugIndex >= 0 && debugIndex !== portIndex) { //remove "-brk" from debug if there
+					match = (/^(--debug)(?:-brk)?(.*)/).exec(debugVars[debugIndex]);
+					debugVars[debugIndex] = match[1] + (match[2] ? match[2] : "");
+				}
 			}
 			options.execArgv = options.execArgv.concat(debugVars);
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class Worker {
 			}
 
 			let portIndex = debugVars.findIndex(debugArg => { //get index of debug port specifier
-				return (/^--(debug|inspect)(-brk)?\d*/).test(debugArg);
+				return (/^--(debug|inspect)(-brk)?(=\d+)?$/).test(debugArg);
 			});
 
 			if (portIndex >= 0) { //set new port, ignore "-brk", it doesn't work

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ class Worker {
 				return (/^--(debug|inspect)(-brk)?\d*/).test(debugArg);
 			});
 
-			if (portIndex > 0) { //set new port, ignore "-brk", it doesn't work
+			if (portIndex >= 0) { //set new port, ignore "-brk", it doesn't work
 				debugVars[portIndex] = ((/^--debug/).test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
 			}
 			options.execArgv = options.execArgv.concat(debugVars);

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ class Worker {
 		var debugVars = process.execArgv.filter(execArg => {
 			return (/(debug|inspect)/).test(execArg);
 		});
-		if (debugVars.length > 0) {
+		if (debugVars.length > 0 && !options.noDebugRedirection) {
 			if (!options.execArgv) { //if no execArgs are given copy all arguments
 				debugVars = process.execArgv;
 				options.execArgv = [];
@@ -49,6 +49,8 @@ class Worker {
 			options.execArgv = options.execArgv.concat(debugVars);
 
 		}
+
+		delete options.noDebugRedirection;
 
 		this.child = fork(worker, args, options);
 		this.onerror = undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ class Worker {
 		var debugVars = process.execArgv.filter(execArg => {
 			return (/(debug|inspect)/).test(execArg);
 		});
-		if (debugVars.lenght > 0) {
+		if (debugVars.length > 0) {
 			if (!options.execArgv) { //if no execArgs are given copy all arguments
 				debugVars = process.execArgv;
 				options.execArgv = [];
@@ -27,7 +27,7 @@ class Worker {
 			});
 
 			if (portIndex > 0) { //set new port, ignore "-brk", it doesn't work
-				debugVars[portIndex] = ((/^--debug/).test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + process.debugPort + 1;
+				debugVars[portIndex] = ((/^--debug/).test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + (process.debugPort + 1);
 			}
 			options.execArgv = options.execArgv.concat(debugVars);
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,27 @@ class Worker {
 			options.cwd = process.cwd();
 		}
 
+		//get all debug related parameters
+		var debugVars = process.execArgv.filter(execArg => {
+			return (/(debug|inspect)/).test(execArg);
+		});
+		if (debugVars.lenght > 0) {
+			if (!options.execArgv) { //if no execArgs are given copy all arguments
+				debugVars = process.execArgv;
+				options.execArgv = [];
+			}
+
+			let portIndex = debugVars.findIndex(debugArg => { //get index of debug port specifier
+				return (/^--(debug|inspect)(-brk)?\d*/).test(debugArg);
+			});
+
+			if (portIndex > 0) { //set new port, ignore "-brk", it doesn't work
+				debugVars[portIndex] = ((/^--debug/).test(debugVars[portIndex]) ? "--debug=" : "--inspect=") + process.debugPort + 1;
+			}
+			options.execArgv = options.execArgv.concat(debugVars);
+
+		}
+
 		this.child = fork(worker, args, options);
 		this.onerror = undefined;
 		this.onmessage = undefined;


### PR DESCRIPTION
to prevent manual handling of debug ports    (#8) in an application which uses tiny-worker, this solution handles the redirection automatically. It gets the current port from `process.execArgv` and adds 1.

Limitations:
it always removes the `-brk` of the debug command for the child process
e.g. `node --inspector=1234 --debug-brk` becomes `node --inspector=1235 --debug` for the child process
this removal is nescessary because of the way tiny-worker passes it's arguments, the message handler must registered immediatly and `-debug-brk` would prevent this