### PR TITLE
Fix crash with minified functions

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -6,19 +6,11 @@ var fs = require("fs"),
     noop = require(path.join(__dirname, "noop.js")),
     events = /^(error|message)$/;
 
-function trim(arg) {
-	return arg.replace(/^(\s+|\t+|\n+)|(\s+|\t+|\n+)$/g, "");
-}
-
-function explode(arg) {
-	return trim(arg).split(new RegExp("\\s*,\\s*"));
-}
-
 function toFunction(arg) {
-	var args = trim(arg.replace(/^.*\(/, "").replace(/[\t|\r|\n|\"|\']+/g, "").replace(/\).*/, "")),
-	    body = trim(arg.replace(/^.*\{/, "").replace(/\}$/, ""));
+	var __worker_evaluated_function_ = null;
+	eval("__worker_evaluated_function_ = (" + arg + ")"); // eslint-disable-line no-eval
 
-	return Function.apply(Function, explode(args).concat([body]));
+	return __worker_evaluated_function_;
 }
 
 // Bootstraps the Worker

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,17 +4,9 @@ const fs = require("fs"),
 	noop = require(path.join(__dirname, "noop.js")),
 	events = /^(error|message)$/;
 
-function trim (arg) {
-	return arg.replace(/^(\s+|\t+|\n+)|(\s+|\t+|\n+)$/g, "");
-}
-
-function explode (arg) {
-	return trim(arg).split(new RegExp("\\s*,\\s*"));
-}
-
 function toFunction (arg) {
 	var __worker_evaluated_function_ = null;
-	eval('__worker_evaluated_function_ = (' + arg + ')')
+	eval("__worker_evaluated_function_ = (" + arg + ")"); // eslint-disable-line no-eval
 
 	return __worker_evaluated_function_;
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,10 +13,10 @@ function explode (arg) {
 }
 
 function toFunction (arg) {
-	const args = trim(arg.replace(/^.*\(/, "").replace(/[\t|\r|\n|\"|\']+/g, "").replace(/\).*/, "")),
-		body = trim(arg.replace(/^.*\{/, "").replace(/\}$/, ""));
+	var __worker_evaluated_function_ = null;
+	eval('__worker_evaluated_function_ = (' + arg + ')')
 
-	return Function.apply(Function, explode(args).concat([body]));
+	return __worker_evaluated_function_;
 }
 
 // Bootstraps the Worker


### PR DESCRIPTION
This is an example of a valid minified function that doesn't work with the regex in toFunction:

    function profileModelWorkerRunner(){var Moment=eval("require")("moment-timezone");self.onmessage=function(event){var profileModelClass=eval("require")(event.data.profileModelPath).default,profileModelWorker=new profileModelClass(Moment,event.data.timezone),params=event.data.params;var result=profileModelWorker.check(params);postMessage(result)}}

I've replaced that code with an eval, which is safer than parsing JS code (which is not a context-free grammar) with regular expressions.