### PR TITLE
Make sure worker terminates when parent process terminates

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -66,3 +66,5 @@ process.once("message", obj => {
 		vm.createScript(exp).runInThisContext();
 	}
 });
+
+process.once("disconnect", () => process.exit());


### PR DESCRIPTION
First of all thanks for creating this package, it's been proven to be pretty useful!

The issue... There have been several reports over at [threads.js](https://github.com/andywer/threads.js) that workers spawned in node.js < 12, using the tiny-worker module, do not terminate when the master process terminates.

## This fix

The safest way to ensure proper exiting is to subscribe to the `disconnect` event as `child_process.fork()` will establish an IPC channel between master and worker process and we know for sure that the worker is not good for anything anymore once that channel is closed.